### PR TITLE
Remove `@Factory` class injection in `nebula-inject-test`

### DIFF
--- a/nebula-inject-test/src/main/java/dev/nebulamc/inject/test/ContainerExtension.java
+++ b/nebula-inject-test/src/main/java/dev/nebulamc/inject/test/ContainerExtension.java
@@ -133,14 +133,12 @@ final class ContainerExtension
         final Container.Builder builder = Container.builder();
 
         for (final Field field : tests.getFactoryFields()) {
-            final Object factory = testDoubles.findService(field.getType());
             field.setAccessible(true);
             try {
-                field.set(context.getRequiredTestInstance(), factory);
+                builder.factory(field.get(context.getRequiredTestInstance()));
             } finally {
                 field.setAccessible(false);
             }
-            builder.factory(factory);
         }
 
         container = new ContainerImpl(

--- a/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/FactoryTest.java
+++ b/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/FactoryTest.java
@@ -18,21 +18,15 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @NebulaInjectTest
 class FactoryTest {
 
-    @Factory IntelCpuFactory intelCpuFactory;
+    @Factory IntelCpuFactory intelCpuFactory = new IntelCpuFactory();
     @Inject IntelCpu intelCpu;
     @Inject Cpu cpu;
     @Inject Computer computer;
 
     @Test
-    void testIntelCpuFactoryIsInjectedIntoFactory() {
-
-        assertEquals(intelCpu, intelCpuFactory.getCpu());
-    }
-
-    @Test
     void testCpuFromFactoryIsInjectedIntoTest() {
 
-        assertEquals(intelCpuFactory.getCpu(), cpu);
+        assertEquals(intelCpu, cpu);
     }
 
     @Test
@@ -81,7 +75,7 @@ class FactoryTest {
     @NebulaInjectTest
     static class NonFactoryTest {
 
-        @Factory Cpu nonFactory;
+        @Factory Cpu nonFactory = new IntelCpu();
 
         /**
          * Required so test can fail.

--- a/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/MockTest.java
+++ b/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/MockTest.java
@@ -85,7 +85,7 @@ class MockTest {
     @NebulaInjectTest
     static class MockFieldTest {
 
-        @Factory IntelCpuFactory intelCpuFactory;
+        @Factory IntelCpuFactory intelCpuFactory = new IntelCpuFactory();
         @Mock(answer = Answers.RETURNS_MOCKS) Cpu cpu;
         @Inject Computer computer;
 

--- a/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/ServiceTest.java
+++ b/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/ServiceTest.java
@@ -53,7 +53,7 @@ class ServiceTest {
     @NebulaInjectTest
     static class FieldTest {
 
-        @Factory IntelCpuFactory intelCpuFactory;
+        @Factory IntelCpuFactory intelCpuFactory = new IntelCpuFactory();
         @Service Cpu cpu = new IntelCpu();
         @Inject Computer computer;
 
@@ -79,7 +79,7 @@ class ServiceTest {
     @NebulaInjectTest
     static class MethodTest {
 
-        @Factory IntelCpuFactory intelCpuFactory;
+        @Factory IntelCpuFactory intelCpuFactory = new IntelCpuFactory();
         Cpu cpu = new IntelCpu();
         @Inject Computer computer;
         @Service String string = "testing parameter resolution";

--- a/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/computer/IntelCpuFactory.java
+++ b/nebula-inject-test/src/test/java/dev/nebulamc/inject/test/computer/IntelCpuFactory.java
@@ -7,17 +7,9 @@ import dev.nebulamc.inject.Service;
 @Factory
 public final class IntelCpuFactory {
 
-    private final IntelCpu intelCpu;
-
-    @Inject
-    public IntelCpuFactory(final IntelCpu intelCpu) {
-
-        this.intelCpu = intelCpu;
-    }
-
     @Service
-    public Cpu getCpu() {
+    public Cpu getCpu(final IntelCpu cpu) {
 
-        return intelCpu;
+        return cpu;
     }
 }


### PR DESCRIPTION
The `Container` doesn't inject `@Factory` classes, so it doesn't make sense why they'd be injected in tests.