### PR TITLE
Remove `Container.create()`

### DIFF
--- a/nebula-inject/src/main/java/dev/nebulamc/inject/Container.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/Container.java
@@ -7,7 +7,7 @@ import dev.nebulamc.inject.internal.ContainerImpl;
  * Represents the dependency injection container.
  *
  * @author Sparky983
- * @see #create()
+ * @see #builder()
  * @since 0.1
  */
 @NullMarked
@@ -22,17 +22,6 @@ public interface Container extends ServiceFinder, ServiceDefinitionRegistry {
     static Builder builder() {
 
         return new ContainerImpl.BuilderImpl();
-    }
-
-    /**
-     * Creates a new dependency injection container.
-     *
-     * @return the container
-     * @since 0.1
-     */
-    static Container create() {
-
-        return builder().build();
     }
 
     /**

--- a/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
@@ -15,8 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * The default implementation of {@link Container}, used by {@link Container#builder()} and
- * {@link Container#create()}.
+ * The default implementation of {@link Container}, used by {@link Container#builder()}.
  * <p>
  * Services are instantiated lazily, when they are first requested and are cached as a singleton.
  *

--- a/nebula-inject/src/test/java/dev/nebulamc/inject/ContainerTest.java
+++ b/nebula-inject/src/test/java/dev/nebulamc/inject/ContainerTest.java
@@ -206,7 +206,7 @@ class ContainerTest {
     @Test
     void testFindServiceWhenServiceIsNotRegistered() {
 
-        final Container container = Container.create();
+        final Container container = Container.builder().build();
 
         assertEquals(Optional.empty(), container.findOptionalService(Car.class));
     }
@@ -214,7 +214,7 @@ class ContainerTest {
     @Test
     void testFindServiceWhenContainer() {
 
-        final Container container = Container.create();
+        final Container container = Container.builder().build();
 
         assertEquals(container, container.findService(Container.class));
     }


### PR DESCRIPTION
Containers are immutable, so there shouldn't be any need to create an empty container.