### PR TITLE
Remove `Container.Builder.singleton` overloads

### DIFF
--- a/docs/nebula-inject/dependency-injection.md
+++ b/docs/nebula-inject/dependency-injection.md
@@ -247,7 +247,7 @@ Additionally, we can manually add objects to the container:
 {% tab title="Java" %}
 ```java
 Container container = Container.builder()
-        .singleton(new PetrolEngine())
+        .singleton(Engine.class, new PetrolEngine())
         .build();
 ```
 {% endtab %}
@@ -255,7 +255,7 @@ Container container = Container.builder()
 {% tab title="Kotlin" %}
 ```kotlin
 val container = Container.builder()
-        .singleton(PetrolEngine())
+        .singleton(Engine::class.java, PetrolEngine())
         .build()
 ```
 {% endtab %}

--- a/nebula-inject/src/main/java/dev/nebulamc/inject/Container.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/Container.java
@@ -68,30 +68,6 @@ public interface Container extends ServiceFinder, ServiceDefinitionRegistry {
         Builder factory(Object factory);
 
         /**
-         * Adds a singleton to the container for all super types of the singleton's type (including
-         * the singleton's type itself).
-         *
-         * @param singleton the singleton instance
-         * @return this builder (for chaining)
-         * @throws NullPointerException if the singleton is {@code null}.
-         * @since 0.1
-         */
-        Builder singleton(Object singleton);
-
-        /**
-         * Adds a singleton to the container for the specified types
-         *
-         * @param types the types to register the singleton as
-         * @param singleton the singleton instance
-         * @return this builder (for chaining)
-         * @param <T> the type of the singleton
-         * @throws NullPointerException if the singleton is {@code null} is the types are or
-         * contains {@code null}.
-         * @since 0.1
-         */
-        <T> Builder singleton(Iterable<Class<? super T>> types, T singleton);
-
-        /**
          * Adds a singleton to the container for the specified types
          *
          * @param type the type to register the singleton as

--- a/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
@@ -168,22 +168,6 @@ public final class ContainerImpl extends AbstractContainer {
             return this;
         }
 
-        @SuppressWarnings("unchecked")
-        private <T> Iterable<Class<? super T>> getAllSupertypes(
-                final Class<T> type) {
-
-            assert type != null;
-
-            final List<Class<? super T>> supertypes = new ArrayList<>();
-
-            for (Class<?> current = type; current != null; current = current.getSuperclass()) {
-                supertypes.add((Class<? super T>) current);
-                supertypes.addAll(Arrays.asList((Class<? super T>[]) current.getInterfaces()));
-            }
-
-            return supertypes;
-        }
-
         @Override
         public Container build() {
 

--- a/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
@@ -157,39 +157,13 @@ public final class ContainerImpl extends AbstractContainer {
             return this;
         }
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        @Override
-        public Container.Builder singleton(final Object singleton) {
-
-            Preconditions.requireNonNull(singleton, "singleton");
-
-            singleton((Iterable) getAllSupertypes(singleton.getClass()), singleton);
-
-            return this;
-        }
-
-        @Override
-        public <T> Container.Builder singleton(final Iterable<Class<? super T>> types,
-                                               final T singleton) {
-
-            Preconditions.requireNonNull(singleton, "singleton");
-            Preconditions.requireNonNull(types, "types");
-
-            for (final Class<? super T> type : types) {
-                serviceDefinitions.serviceDefinition(
-                        new SingletonServiceDefinition<>(type, singleton));
-            }
-
-            return this;
-        }
-
         @Override
         public <T> Container.Builder singleton(final Class<? super T> type, final T singleton) {
 
-            Preconditions.requireNonNull(singleton, "singleton");
             Preconditions.requireNonNull(type, "type");
+            Preconditions.requireNonNull(singleton, "singleton");
 
-            singleton(List.of(type), singleton);
+            serviceDefinitions.serviceDefinition(new SingletonServiceDefinition<>(type, singleton));
 
             return this;
         }

--- a/nebula-inject/src/test/java/dev/nebulamc/inject/ContainerTest.java
+++ b/nebula-inject/src/test/java/dev/nebulamc/inject/ContainerTest.java
@@ -4,7 +4,6 @@ import dev.nebulamc.inject.car.Car;
 import dev.nebulamc.inject.car.CarFactory;
 import dev.nebulamc.inject.car.Engine;
 import dev.nebulamc.inject.car.Sedan;
-import dev.nebulamc.inject.car.Suv;
 import dev.nebulamc.inject.car.V8Engine;
 import dev.nebulamc.inject.car.Wheels;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,7 @@ class ContainerTest {
 
         final Container child = Container.builder()
                 .parent(parent)
-                .singleton(wheels)
+                .singleton(Wheels.class, wheels)
                 .build();
 
         assertEquals(engine, child.findService(Engine.class));
@@ -55,9 +54,6 @@ class ContainerTest {
 
         final Container.Builder builder = Container.builder();
 
-        assertThrows(NullPointerException.class, () -> builder.singleton(null));
-        assertThrows(NullPointerException.class, () -> builder
-                .singleton((Iterable<Class<? super Object>>) null, null));
         assertThrows(NullPointerException.class, () -> builder
                 .singleton((Class<? super Object>) null, null));
     }
@@ -67,20 +63,14 @@ class ContainerTest {
 
         final V8Engine engine = new V8Engine();
         final Wheels wheels = new Wheels();
-        final Suv suv = new Suv(engine, wheels);
 
         final Container container = Container.builder()
-                .singleton(engine)
+                .singleton(Engine.class, engine)
                 .singleton(Wheels.class, wheels)
-                .singleton(List.of(Suv.class, Car.class), suv)
                 .build();
 
-        assertEquals(engine, container.findService(V8Engine.class));
-        assertEquals(engine, container.findService(Object.class));
         assertEquals(engine, container.findService(Engine.class));
         assertEquals(wheels, container.findService(Wheels.class));
-        assertEquals(suv, container.findService(Suv.class));
-        assertEquals(suv, container.findService(Car.class));
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -99,8 +89,8 @@ class ContainerTest {
         final Wheels wheels = new Wheels();
 
         final Container container = Container.builder()
-                .singleton(engine)
-                .singleton(wheels)
+                .singleton(Engine.class, engine)
+                .singleton(Wheels.class, wheels)
                 .factory(new CarFactory())
                 .build();
 
@@ -179,8 +169,8 @@ class ContainerTest {
         final Wheels wheels = new Wheels();
 
         final Container container = Container.builder()
-                .singleton(engine)
-                .singleton(wheels)
+                .singleton(Engine.class, engine)
+                .singleton(Wheels.class, wheels)
                 .build();
 
         final Car car = container.findService(Sedan.class);
@@ -194,7 +184,7 @@ class ContainerTest {
 
         final Wheels wheels = new Wheels();
         final Container parent = Container.builder()
-                .singleton(wheels)
+                .singleton(Wheels.class, wheels)
                 .build();
         final Container child = Container.builder()
                 .parent(parent)


### PR DESCRIPTION
They work too differently how to the rest of `nebula-inject` works. Most of `nebula-inject` is explicit about the type of a service and only allows a single type.