### PR TITLE
Remove redundant wildcard

### DIFF
--- a/nebula-inject/src/main/java/dev/nebulamc/inject/Container.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/Container.java
@@ -101,7 +101,7 @@ public interface Container extends ServiceFinder, ServiceDefinitionRegistry {
          * @throws NullPointerException if the singleton or type are {@code null}.
          * @since 0.1
          */
-        <T> Builder singleton(Class<? super T> type, T singleton);
+        <T> Builder singleton(Class<T> type, T singleton);
 
         /**
          * Adds a service definition to the container.

--- a/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
+++ b/nebula-inject/src/main/java/dev/nebulamc/inject/internal/ContainerImpl.java
@@ -184,7 +184,7 @@ public final class ContainerImpl extends AbstractContainer {
         }
 
         @Override
-        public <T> Container.Builder singleton(final Class<? super T> type, final T singleton) {
+        public <T> Container.Builder singleton(final Class<T> type, final T singleton) {
 
             Preconditions.requireNonNull(singleton, "singleton");
             Preconditions.requireNonNull(type, "type");


### PR DESCRIPTION
Technically a breaking change. Only calls like this will break though:
```java
Container.builder().<String>singleton(CharSequence.class, "some string");
```